### PR TITLE
Small Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[Try it out!](http://htmlpreview.github.io/?https://github.com/the42/bevaddressapi/blob/master/bevaddressftssearch.html)
+[Try it out on our website!](https://www.offene-adressen.at)
+[Try it out via github preview!](http://htmlpreview.github.io/?https://github.com/the42/bevaddressapi/blob/master/bevaddressftssearch.html)
 
 A Websocket API to provide search functionality in Austria's Address register
 as published under http://www.bev.gv.at/portal/page?_pageid=713,2601271&_dad=portal&_schema=PORTAL

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[Try it out on our website!](https://www.offene-adressen.at)
-[Try it out via github preview!](http://htmlpreview.github.io/?https://github.com/the42/bevaddressapi/blob/master/bevaddressftssearch.html)
+Working Demos can be found here:
+* [Official Website](https://www.offene-adressen.at)
+* [GitHub Preview](http://htmlpreview.github.io/?https://github.com/the42/bevaddressapi/blob/master/bevaddressftssearch.html)
 
 A Websocket API to provide search functionality in Austria's Address register
 as published under http://www.bev.gv.at/portal/page?_pageid=713,2601271&_dad=portal&_schema=PORTAL

--- a/bevaddressftssearch.html
+++ b/bevaddressftssearch.html
@@ -114,7 +114,6 @@
 				class="form-control"
 				name="addressfts"
 				id="addressfts"
-				value="Wien, erster bezirk, Akademiestrasse"
 				placeholder="Wien, erster bezirk, Akademiestrasse"
 				autofocus
 			/>


### PR DESCRIPTION
This PR fixes the input box to correctly only use "placeholder" and not "value" so that the user doesnt have to delete the placeholder text first and updates the readme to include the new offene-adressen link.
