### PR TITLE
Fixed duplicate stemming during auto completion

### DIFF
--- a/bevaddress.go
+++ b/bevaddress.go
@@ -31,7 +31,7 @@ type connection struct {
 const maxrowsFTS = 200
 const defaultrowsFTS = 25
 const nearbymeters = 50 // default distance to search nearby addresses in meter
-const autocomplete = `search @@ to_tsquery(plainto_tsquery('german', $1)::text || ':*')`
+const autocomplete = `search @@ plainto_tsquery('german', $1 || ':*')`
 const noautocomplete = `search @@ plainto_tsquery('german', $1)`
 
 const fulltextSearchSQL = `select addritems.plz, addritems.gemeindename, addritems.ortsname, addritems.strassenname, addritems.hausnrzahl1, ST_Y(adresse.latlong), ST_X(adresse.latlong)

--- a/bevaddress.go
+++ b/bevaddress.go
@@ -31,7 +31,7 @@ type connection struct {
 const maxrowsFTS = 200
 const defaultrowsFTS = 25
 const nearbymeters = 50 // default distance to search nearby addresses in meter
-const autocomplete = `search @@ plainto_tsquery('german', $1 || ':*')`
+const autocomplete = `search @@ (plainto_tsquery('german', $1)::text || ':*')::tsquery`
 const noautocomplete = `search @@ plainto_tsquery('german', $1)`
 
 const fulltextSearchSQL = `select addritems.plz, addritems.gemeindename, addritems.ortsname, addritems.strassenname, addritems.hausnrzahl1, ST_Y(adresse.latlong), ST_X(adresse.latlong)


### PR DESCRIPTION
Right now, if you search for "Mariazeller Gasse", the string will be stemmed twice:

```
project=# select plainto_tsquery('german', 'Mariazeller Gasse');
   plainto_tsquery    
----------------------
 'mariazell' & 'gass'
(1 row)

project=# select to_tsquery(plainto_tsquery('german', 'Mariazeller Gasse')::text);
     to_tsquery      
---------------------
 'mariazel' & 'gass'
(1 row)
```

In the `addritems` table, "Mariazeller" is stemmed once (with to_tsvector) to `mariazell`. The second sample searches for `mariazel` though which isn't found.